### PR TITLE
Ditch version_compare for composer/semver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "symfony/console": "^2.7.3",
         "league/climate": "^3.2.0",
         "knplabs/packagist-api": "^1.3.0",
-        "danielstjules/stringy": "^2.0.0"
+        "danielstjules/stringy": "^2.0.0",
+        "composer/semver": "^1.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.6"

--- a/src/CheckCommand.php
+++ b/src/CheckCommand.php
@@ -185,7 +185,7 @@ class CheckCommand extends Command
                 $current = $this->normalize($version);
                 $latest = $this->getLatest($package->getVersions());
 
-                if (version_compare($version, $latest, '<') && $current !== $latest) {
+                if (Comparator::lessThan($version, $latest)) {
                     $latest = $this->diff($current, $latest);
 
                     array_push($versions, [$name, $current, '→', $latest]);
@@ -225,7 +225,7 @@ class CheckCommand extends Command
      */
     private function normalize($version)
     {
-        $version = preg_replace('/(v|\^|~)/', '', $version);
+        $version = preg_replace('/^(v|\^|~)/', '', $version);
 
         if (preg_match('/^\d\.\d$/', $version)) {
             $version .= '.0';

--- a/src/CheckCommand.php
+++ b/src/CheckCommand.php
@@ -11,6 +11,7 @@
 
 namespace Vinkla\Climb;
 
+use Composer\Semver\Comparator;
 use Guzzle\Http\Exception\ClientErrorResponseException;
 use League\CLImate\CLImate;
 use Packagist\Api\Client;
@@ -210,12 +211,8 @@ class CheckCommand extends Command
             return $this->normalize($version->getVersion());
         }, $versions);
 
-        $versions = array_filter($versions, function ($version) {
-            return preg_match('/^v?\d\.\d(\.\d)?$/', $version);
-        });
-
         return array_reduce($versions, function ($carry, $item) {
-            return version_compare($carry, $item, '>') ? $carry : $item;
+            return Comparator::greaterThan($carry, $item) ? $carry : $item;
         }, '0.0.0');
     }
 

--- a/src/CheckCommand.php
+++ b/src/CheckCommand.php
@@ -185,7 +185,7 @@ class CheckCommand extends Command
                 $current = $this->normalize($version);
                 $latest = $this->getLatest($package->getVersions());
 
-                if (Comparator::lessThan($version, $latest)) {
+                if (Comparator::lessThan($current, $latest)) {
                     $latest = $this->diff($current, $latest);
 
                     array_push($versions, [$name, $current, '→', $latest]);


### PR DESCRIPTION
Use the `composer/semver` package to compare version numbers. This also includes a fix for version number normalisation.
