### PR TITLE
Add a box.json file to build phar file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/climb.phar
 composer.lock
 phpunit.xml
 vendor

--- a/box.json
+++ b/box.json
@@ -1,0 +1,21 @@
+{
+    "chmod": "0755",
+    "directories": [
+        "src"
+    ],
+    "files": [
+        "LICENSE",
+        "./vendor/guzzle/guzzle/src/Guzzle/Http/Resources/cacert.pem"
+    ],
+    "finder": [
+        {
+            "name": "*.php",
+            "exclude": ["Tests", "tests"],
+            "in": "vendor"
+        }
+    ],
+    "git-version": "package_version",
+    "main": "bin/climb",
+    "output": "climb.phar",
+    "stub": true
+}

--- a/src/Application.php
+++ b/src/Application.php
@@ -25,7 +25,7 @@ class Application extends Console
      *
      * @var string
      */
-    const VERSION = '0.5.0';
+    const VERSION = '@package_version@';
 
     /**
      * Create a new application instance.


### PR DESCRIPTION
Hello

Using `composer global` commands to install climb is nice but I try to avoid it because it often conflicts with other "globally installed" packages. The dependencies of every global packages are shared and then you cannot install it if for instance you installed a tool using a different version of guzzle.

What I usually do is to provide a compiled version of the script (via a phar file) that I put in my PATH.
With this PR you can easily build a phar file using [Box](http://box-project.github.io/box2/).

```
composer install --no-dev
box build
mv climb.phar /usr/local/bin/climb
```

You can also join the phar file in each release.
