### PR TITLE
Lower symfony minimum requirement to 2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "symfony/console": "^2.7",
+        "symfony/console": "^2.6",
         "league/climate": "^3.2",
         "knplabs/packagist-api": "^1.3",
         "composer/semver": "^1.1"


### PR DESCRIPTION
Somebody reported on https://jenssegers.com/78/list-outdated-composer-packages-with-climb that he was having symfony/console conflicts when installing climb. I locally tested compatibility with symfony 2.6 and everything seems to be ok, so we should be able to lower the minimum requirements for symfony/console without any issues.
