### PR TITLE
output formats

### DIFF
--- a/src/Commands/OutdatedCommand.php
+++ b/src/Commands/OutdatedCommand.php
@@ -63,7 +63,7 @@ class OutdatedCommand extends Command
 
         try {
             $format = $input->getOption('format');
-            $formatClass = '\\Vinkla\\Climb\\Formatter\\' . ucfirst($format);
+            $formatClass = '\\Vinkla\\Climb\\Formatter\\'.ucfirst($format);
             if (!class_exists($formatClass)) {
                 throw new ClimbException(sprintf('Output format "%s" is not valid', $format));
             }

--- a/src/Formatter/Console.php
+++ b/src/Formatter/Console.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of Climb.
+ *
+ * (c) Vincent Klaiber <hello@vinkla.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Vinkla\Climb\Formatter;
+
+use League\CLImate\CLImate;
+
+/**
+ * This is the console formatter.
+ *
+ * @author Julián Gutiérrez <juliangut@gmail.com>
+ */
+class Console implements Format
+{
+    /**
+     * @inheritDoc
+     */
+    public function render(CLImate $climate, array $outdated, array $upgradable)
+    {
+        $climate->br();
+
+        if (!$outdated && !$upgradable) {
+            $climate->write('All dependencies match the latest package versions <green>:)</green>')->br();
+
+            return;
+        }
+
+        if ($outdated) {
+            $outdated = array_map([$this, 'diff'], $outdated);
+
+            $climate->columns($outdated, 3)->br();
+        }
+
+        if ($upgradable) {
+            $upgradable = array_map([$this, 'diff'], $upgradable);
+
+            $climate->write('The following dependencies are satisfied by their declared version constraint, but the installed versions are behind. You can install the latest versions without modifying your composer.json file by using \'composer update\'.')->br();
+
+            $climate->columns($upgradable, 3)->br();
+        }
+    }
+
+    /**
+     * Get the diff between the current and latest version.
+     *
+     * @param array $package
+     *
+     * @return array
+     */
+    private function diff(array $package)
+    {
+        $current = $package[1];
+        $latest = $package[2];
+
+        $needle = 0;
+
+        while ($needle < strlen($current) && $needle < strlen($latest)) {
+            if ($current[$needle] !== $latest[$needle]) {
+                break;
+            }
+
+            $needle++;
+        }
+
+        $package[2] = '→';
+        $package[3] = substr($latest, 0, $needle) . '<green>' . substr($latest, $needle) . '</green>';
+
+        return $package;
+    }
+}

--- a/src/Formatter/Console.php
+++ b/src/Formatter/Console.php
@@ -21,7 +21,7 @@ use League\CLImate\CLImate;
 class Console implements Format
 {
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function render(CLImate $climate, array $outdated, array $upgradable)
     {
@@ -71,7 +71,7 @@ class Console implements Format
         }
 
         $package[2] = '→';
-        $package[3] = substr($latest, 0, $needle) . '<green>' . substr($latest, $needle) . '</green>';
+        $package[3] = substr($latest, 0, $needle).'<green>'.substr($latest, $needle).'</green>';
 
         return $package;
     }

--- a/src/Formatter/Format.php
+++ b/src/Formatter/Format.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of Climb.
+ *
+ * (c) Vincent Klaiber <hello@vinkla.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Vinkla\Climb\Formatter;
+
+use League\CLImate\CLImate;
+
+/**
+ * Climb formatter interface.
+ *
+ * @author Julián Gutiérrez <juliangut@gmail.com>
+ */
+interface Format
+{
+    /**
+     * Produce final output.
+     *
+     * @param \League\CLImate\CLImate $climate
+     * @param array $outdated
+     * @param array $upgradable
+     */
+    public function render(CLImate $climate, array $outdated, array $upgradable);
+}

--- a/src/Formatter/Json.php
+++ b/src/Formatter/Json.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of Climb.
+ *
+ * (c) Vincent Klaiber <hello@vinkla.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Vinkla\Climb\Formatter;
+
+use League\CLImate\CLImate;
+
+/**
+ * This is the JSON formatter.
+ *
+ * @author Julián Gutiérrez <juliangut@gmail.com>
+ */
+class Json implements Format
+{
+    /**
+     * @inheritDoc
+     */
+    public function render(CLImate $climate, array $outdated, array $upgradable)
+    {
+        $output = [
+            'outdated' => [],
+            'upgradable' => [],
+        ];
+
+        if ($outdated || $upgradable) {
+            if ($outdated) {
+                $output['outdated'] = $this->formatPackage($outdated);
+            }
+
+            if ($upgradable) {
+                $output['upgradable'] = $this->formatPackage($upgradable);
+            }
+        }
+
+        $climate->write(json_encode($output));
+    }
+
+    /**
+     * Format package information.
+     *
+     * @param array $packages
+     */
+    private function formatPackage(array $packages)
+    {
+        $output = [];
+
+        foreach ($packages as $package) {
+            $output[] = [
+                $package[0] => [
+                    'current' => $package[1],
+                    'update'  => $package[2],
+                ],
+            ];
+        }
+
+        return $output;
+    }
+}

--- a/src/Formatter/Json.php
+++ b/src/Formatter/Json.php
@@ -21,7 +21,7 @@ use League\CLImate\CLImate;
 class Json implements Format
 {
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function render(CLImate $climate, array $outdated, array $upgradable)
     {
@@ -56,7 +56,7 @@ class Json implements Format
             $output[] = [
                 $package[0] => [
                     'current' => $package[1],
-                    'update'  => $package[2],
+                    'update' => $package[2],
                 ],
             ];
         }

--- a/src/Formatter/Xml.php
+++ b/src/Formatter/Xml.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of Climb.
+ *
+ * (c) Vincent Klaiber <hello@vinkla.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Vinkla\Climb\Formatter;
+
+use DOMDocument;
+use DOMElement;
+use League\CLImate\CLImate;
+
+/**
+ * This is the XML formatter.
+ *
+ * @author Julián Gutiérrez <juliangut@gmail.com>
+ */
+class Xml implements Format
+{
+    /**
+     * @inheritDoc
+     */
+    public function render(CLImate $climate, array $outdated, array $upgradable)
+    {
+        $dom = new DOMDocument('1.0', 'UTF-8');
+
+        $climb = $dom->createElement('climb');
+
+        $outdatedElement = $dom->createElement('outdated');
+        if (count($outdated)) {
+            $outdatedElement = $this->formatPackage($dom, $outdatedElement, $outdated);
+        }
+        $climb->appendChild($outdatedElement);
+
+        $upgradableElement = $dom->createElement('upgradable');
+        if (count($upgradable)) {
+            $upgradableElement = $this->formatPackage($dom, $upgradableElement, $upgradable);
+        }
+        $climb->appendChild($upgradableElement);
+
+        $dom->appendChild($climb);
+
+        $climate->write(rtrim($dom->saveXML(), "\n"));
+    }
+
+    /**
+     * Format package information.
+     *
+     * @param DOMDocument $dom
+     * @param DOMElement $element
+     * @param array $packages
+     */
+    private function formatPackage(DOMDocument $dom, DOMElement $element, array $packages)
+    {
+        foreach ($packages as $package) {
+            $pack = $dom->createElement('package');
+
+            $pack->setAttribute('name', $package[0]);
+            $pack->setAttribute('current', $package[1]);
+            $pack->setAttribute('update', $package[2]);
+
+            $element->appendChild($pack);
+        }
+
+        return $element;
+    }
+}

--- a/src/Formatter/Xml.php
+++ b/src/Formatter/Xml.php
@@ -23,7 +23,7 @@ use League\CLImate\CLImate;
 class Xml implements Format
 {
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function render(CLImate $climate, array $outdated, array $upgradable)
     {


### PR DESCRIPTION
Support different output formats `--format=json`:
- console, outputs pretty text, it is the default format, respects former behaviour
- json, outputs JSON object with "outdated" and "upgradable" keys
- xml, outputs XML with "climb" base element and "outdated" and "upgradable" as its children

Again, the purpose of this PR is to improve integration on CI processes, this way you can output climb report in a format that can be further parsed
