### PR TITLE
outdated/upgradable and fail flags

### DIFF
--- a/src/Commands/GlobalOutdatedCommand.php
+++ b/src/Commands/GlobalOutdatedCommand.php
@@ -11,6 +11,7 @@
 
 namespace Vinkla\Climb\Commands;
 
+use Symfony\Component\Console\Input\InputOption;
 use Vinkla\Climb\Ladder;
 
 /**
@@ -30,6 +31,9 @@ class GlobalOutdatedCommand extends OutdatedCommand
     {
         $this->setName('global');
         $this->setDescription('Find newer versions of dependencies than what your global composer.json allows');
+        $this->addOption('no-outdated', null, InputOption::VALUE_NONE, 'Do not check outdated dependencies');
+        $this->addOption('no-upgradable', null, InputOption::VALUE_NONE, 'Do not check upgradable dependencies');
+        $this->addOption('fail', null, InputOption::VALUE_NONE, 'Fail when outdated and/or upgradable');
 
         $this->ladder = new Ladder(getenv('HOME').'/.composer');
     }

--- a/src/Commands/OutdatedCommand.php
+++ b/src/Commands/OutdatedCommand.php
@@ -12,6 +12,7 @@
 namespace Vinkla\Climb\Commands;
 
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Vinkla\Climb\Ladder;
 use Vinkla\Climb\Version;
@@ -40,6 +41,9 @@ class OutdatedCommand extends Command
     {
         $this->setName('outdated');
         $this->setDescription('Find newer versions of dependencies than what your composer.json allows');
+        $this->addOption('no-outdated', null, InputOption::VALUE_NONE, 'Do not check outdated dependencies');
+        $this->addOption('no-upgradable', null, InputOption::VALUE_NONE, 'Do not check upgradable dependencies');
+        $this->addOption('fail', null, InputOption::VALUE_NONE, 'Fail when outdated and/or upgradable');
 
         $this->ladder = new Ladder();
     }
@@ -70,9 +74,9 @@ class OutdatedCommand extends Command
         foreach ($packages as $package) {
             $diff = Version::diff($package->getVersion(), $package->getLatestVersion());
 
-            if ($package->isUpgradable()) {
+            if ($package->isUpgradable() && !$input->getOption('no-upgradable')) {
                 $upgradable[] = [$package->getName(), $package->getVersion(), '→', $diff];
-            } else {
+            } elseif (!$input->getOption('no-outdated')) {
                 $outdated[] = [$package->getName(), $package->getVersion(), '→', $diff];
             }
         }
@@ -84,6 +88,10 @@ class OutdatedCommand extends Command
         if ($upgradable) {
             $output->writeln('The following dependencies are satisfied by their declared version constraint, but the installed versions are behind. You can install the latest versions without modifying your composer.json file by using \'composer update\'.');
             $output->columns($upgradable);
+        }
+
+        if ($input->getOption('fail') && ($outdated || $upgradable)) {
+            return 1;
         }
 
         return 0;


### PR DESCRIPTION
Added flags to control outdated command:
- `--no-outdated` to exclude outdated packages
- `--no-upgradable` to eclude upgradable packages
- `--fail` to `return 1` if outdated and/or upgradable

Covers #21 and #23 
