### PR TITLE
output formatters

### DIFF
--- a/src/Commands/OutdatedCommand.php
+++ b/src/Commands/OutdatedCommand.php
@@ -35,8 +35,8 @@ class OutdatedCommand extends Command
         $this->setDescription('Find newer versions of dependencies than what your composer.json allows');
         $this->addOption('directory', null, InputOption::VALUE_REQUIRED, 'Composer files directory');
         $this->addOption('global', 'g', InputOption::VALUE_NONE, 'Run on globally installed packages');
-        $this->addOption('no-outdated', null, InputOption::VALUE_NONE, 'Do not check outdated dependencies');
-        $this->addOption('no-upgradable', null, InputOption::VALUE_NONE, 'Do not check upgradable dependencies');
+        $this->addOption('outdated', null, InputOption::VALUE_NONE, 'Only check outdated dependencies');
+        $this->addOption('upgradable', null, InputOption::VALUE_NONE, 'Only check upgradable dependencies');
         $this->addOption('format', null, InputOption::VALUE_OPTIONAL, 'Output format', 'console');
     }
 
@@ -66,14 +66,14 @@ class OutdatedCommand extends Command
 
         foreach ($packages as $package) {
             if ($package->isUpgradable()) {
-                if (!$input->getOption('no-upgradable')) {
+                if (!$input->getOption('outdated')) {
                     $upgradable[] = [
                         $package->getName(),
                         $package->getVersion(),
                         $package->getLatestVersion(),
                     ];
                 }
-            } elseif (!$input->getOption('no-outdated')) {
+            } elseif (!$input->getOption('upgradable')) {
                 $outdated[] = [
                     $package->getName(),
                     $package->getVersion(),

--- a/src/Formatter/Console.php
+++ b/src/Formatter/Console.php
@@ -23,7 +23,7 @@ class Console implements Format
     /**
      * {@inheritdoc}
      */
-    public function render(OutputInterface $output, array $outdated, array $upgradable)
+    public function render(OutputInterface $output, array $outdated = [], array $upgradable = [])
     {
         $output->newLine();
 

--- a/src/Formatter/Console.php
+++ b/src/Formatter/Console.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of Climb.
+ *
+ * (c) Vincent Klaiber <hello@vinkla.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Vinkla\Climb\Formatter;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * This is the console formatter.
+ *
+ * @author Julián Gutiérrez <juliangut@gmail.com>
+ */
+class Console implements Format
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function render(OutputInterface $output, array $outdated, array $upgradable)
+    {
+        $output->newLine();
+
+        if (!$outdated && !$upgradable) {
+            $output->writeln('All dependencies match the latest package versions <info>:)</info>');
+            $output->newLine();
+
+            return;
+        }
+
+        if ($outdated) {
+            $output->columns($this->formatPackages($outdated, $output));
+        }
+
+        if ($upgradable) {
+            $output->writeln('The following dependencies are satisfied by their declared version constraint, but the installed versions are behind. You can install the latest versions without modifying your composer.json file by using <fg=blue>composer update</>.');
+            $output->newLine();
+            $output->columns($this->formatPackages($upgradable, $output));
+        }
+    }
+
+    /**
+     * Format packages information.
+     *
+     * @param array $packages
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     *
+     * @return array
+     */
+    private function formatPackages(array $packages, OutputInterface $output)
+    {
+        return array_map(
+            function (array $package) use ($output) {
+                $package[3] = $output->versionDiff($package[1], $package[2]);
+                $package[2] = '→';
+
+                return $package;
+            },
+            $packages
+        );
+    }
+}

--- a/src/Formatter/Format.php
+++ b/src/Formatter/Format.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of Climb.
+ *
+ * (c) Vincent Klaiber <hello@vinkla.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Vinkla\Climb\Formatter;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Climb formatter interface.
+ *
+ * @author Julián Gutiérrez <juliangut@gmail.com>
+ */
+interface Format
+{
+    /**
+     * Produce final output.
+     *
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @param array $outdated
+     * @param array $upgradable
+     */
+    public function render(OutputInterface $output, array $outdated = [], array $upgradable = []);
+}

--- a/src/Formatter/Json.php
+++ b/src/Formatter/Json.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of Climb.
+ *
+ * (c) Vincent Klaiber <hello@vinkla.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Vinkla\Climb\Formatter;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * This is the JSON formatter.
+ *
+ * @author Julián Gutiérrez <juliangut@gmail.com>
+ */
+class Json implements Format
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function render(OutputInterface $output, array $outdated = [], array $upgradable = [])
+    {
+        $output->writeln(json_encode([
+            'outdated' => $this->formatPackages($outdated),
+            'upgradable' => $this->formatPackages($upgradable),
+        ]));
+    }
+
+    /**
+     * Format packages information.
+     *
+     * @param array $packages
+     *
+     * @return array
+     */
+    private function formatPackages(array $packages)
+    {
+        return array_map(
+            function (array $package) {
+                return [
+                    'current' => $package[1],
+                    'latest' => $package[2],
+                ];
+            },
+            $packages
+        );
+    }
+}

--- a/src/Formatter/Xml.php
+++ b/src/Formatter/Xml.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of Climb.
+ *
+ * (c) Vincent Klaiber <hello@vinkla.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Vinkla\Climb\Formatter;
+
+use DOMDocument;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * This is the XML formatter.
+ *
+ * @author Julián Gutiérrez <juliangut@gmail.com>
+ */
+class Xml implements Format
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function render(OutputInterface $output, array $outdated = [], array $upgradable = [])
+    {
+        $dom = new DOMDocument('1.0', 'UTF-8');
+
+        $climb = $dom->createElement('climb');
+
+        $outdatedElement = $dom->createElement('outdated');
+        foreach ($this->formatPackages($outdated, $dom) as $package) {
+            $outdatedElement->appendChild($package);
+        }
+        $climb->appendChild($outdatedElement);
+
+        $upgradableElement = $dom->createElement('upgradable');
+        foreach ($this->formatPackages($upgradable, $dom) as $package) {
+            $upgradableElement->appendChild($package);
+        }
+        $climb->appendChild($upgradableElement);
+
+        $dom->appendChild($climb);
+
+        $output->writeln(rtrim($dom->saveXML(), "\n"));
+    }
+
+    /**
+     * Format packages information.
+     *
+     * @param array $packages
+     * @param \DOMDocument $dom
+     *
+     * @return array
+     */
+    private function formatPackages(array $packages, DOMDocument $dom)
+    {
+        return array_map(
+            function (array $package) use ($dom) {
+                $pack = $dom->createElement('package');
+
+                $pack->setAttribute('name', $package[0]);
+                $pack->setAttribute('current', $package[1]);
+                $pack->setAttribute('latest', $package[2]);
+
+                return $pack;
+            },
+            $packages
+        );
+    }
+}


### PR DESCRIPTION
Output formatting `--format`flag

Supported formats:
- console, outputs pretty text, it is the default format, respects former behavior
- json, outputs JSON object with "outdated" and "upgradable" keys
- xml, outputs XML with "climb" base element and "outdated" and "upgradable" as its children

Update of PR #40
