### PR TITLE
Enable gzip compression of .phar

### DIFF
--- a/box.json
+++ b/box.json
@@ -17,5 +17,6 @@
     "git-version": "package_version",
     "main": "bin/climb",
     "output": "climb.phar",
+    "compression": "GZ",
     "stub": true
 }


### PR DESCRIPTION
This reduces the size of the .phar from 1.8M to 591K
